### PR TITLE
Remove needless append

### DIFF
--- a/obvious-parentheses.el
+++ b/obvious-parentheses.el
@@ -47,11 +47,10 @@
         (setq lightvals (list 0.65 0.55))
       (setq lightvals (list 0.35 0.30)))
 
-    (append
-                 (dolist (n'(.71 .3 .11 .01))
-                   (push (hsl-to-hex (+ n 0.0) 1.0 (nth 0 lightvals)) hexcolors))
-                 (dolist (n '(.81 .49 .17 .05))
-                   (push (hsl-to-hex (+ n 0.0) 1.0 (nth 1 lightvals)) hexcolors)))
+     (dolist (n '(.71 .3 .11 .01))
+       (push (hsl-to-hex (+ n 0.0) 1.0 (nth 0 lightvals)) hexcolors))
+     (dolist (n '(.81 .49 .17 .05))
+       (push (hsl-to-hex (+ n 0.0) 1.0 (nth 1 lightvals)) hexcolors))
     (reverse hexcolors)))
 
 ;;;###autoload


### PR DESCRIPTION
BTW, all functions and global variables should have package prefix for avoiding name confliction because Emacs has only one name space. For example `colorize-brackets` -> `obvious-parentheses- colorize-brackets` etc. And this package does not call `provide`(like `(provide 'obvious-parentheses)` so user cannot load it by `require`).
